### PR TITLE
Fixed timeout after idling for a while

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,11 +113,13 @@ def main(Session):
         elif scanned == "u":
             font.score += 1
             font = None
+            session.commit()
 
         # User wants to downvote the logo
         elif scanned == "d":
             font.score -= 1
             font = None
+            session.commit()
 
         # User entered nothing, refresh screen
         elif scanned == "":

--- a/app.py
+++ b/app.py
@@ -101,7 +101,9 @@ def main(Session):
     with Session() as session:
         font = randomFont(session)
         startScreen(font)
-        scanned = input(question("\nType nickname or scan barcode: "))
+    
+    scanned = input(question("\nType nickname or scan barcode: "))
+    with Session() as session:
 
         users = []
 

--- a/database.py
+++ b/database.py
@@ -9,7 +9,9 @@ with open("credentials.txt", 'r') as c_fh:
 SQLALCHEMY_DATABASE_URI = f"mysql+pymysql://{username}:{password}@ackbar-vm/ackbar?charset=utf8mb4"
 
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URI, echo=False
+    SQLALCHEMY_DATABASE_URI,
+    echo=False,
+    pool_pre_ping=True
 )
 
 Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/database.py
+++ b/database.py
@@ -11,7 +11,7 @@ SQLALCHEMY_DATABASE_URI = f"mysql+pymysql://{username}:{password}@ackbar-vm/ackb
 engine = create_engine(
     SQLALCHEMY_DATABASE_URI,
     echo=False,
-    pool_pre_ping=True
+    pool_recycle=3600
 )
 
 Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
Default MariaDB behaviour is to close idle connections after 8 hours. Default SQLAlchemy behaviour on the other hand is to reuse a pool of connections unless explicitly told otherwise. This pull request changes two things;

1) SQLAlchemy is now instructed to refresh the connection pool when it's older than an hour
2) Database connection is now established AFTER user input

Since running this branch no timeouts have occurred, so it's ~~Morbin time~~ time to merge.