### PR TITLE
Add backward compatible commands

### DIFF
--- a/app.py
+++ b/app.py
@@ -185,7 +185,7 @@ def main(Session):
                 scanned = input(question("\nType command or scan product: "))
 
                 # User wants to deposit money
-                if scanned.lower() == "cash":
+                if scanned.lower() in ["cash", "deposit"]:
                     deposit += input_deposit()
 
                 # User wants to transfer money
@@ -206,7 +206,7 @@ def main(Session):
                         session.add( BankStorting(user_id=users[0].id, bedrag=bedrag, code=code) )
 
                 # User wants to finish transaction
-                elif scanned.lower() == "accept":
+                elif scanned.lower() in ["accept", "checkout"]:
                     if performCheckout(users[0], products, deposit, session,transfers):
                         print(succes("Transaction confirmed!"))
                         time.sleep(2)
@@ -216,7 +216,7 @@ def main(Session):
                         time.sleep(1)
 
                 # User wants to cancel transaction
-                elif scanned.lower() == "cancel":
+                elif scanned.lower() in ["cancel", "abort"]:
                     print(warning(f"Transaction canceled!"))
                     session.rollback()
                     userBusy = False


### PR DESCRIPTION
This PR adds the old ACKbar commands for backward compatibility (And therefore fixes #10).

I've created this request and PR because I have the old barcodes printed on by ACKspace badge for convenience; it might be a niche thing, but having a `accept` and `checkout` to complete makes things easier either way. 